### PR TITLE
Add HtmlString Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gbuckingham89/laraflash v4.x
+# gbuckingham89/laraflash v5.x
 
 A simple package for handling flash messages / notifications in Laravel. Written to suit my needs - but hopefully someone else will find it useful too.
 
-The current version requires Laravel 7.0 (PHP 7.4) or greater. If you have a project that requires a lower version of PHP or Laravel, check the requirements of the older releases.
+The current version requires Laravel 7.0 & PHP 8.0 or greater. If you have a project that requires a lower version of PHP or Laravel, check the requirements of the older releases.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "source": "https://github.com/gbuckingham89/laraflash"
   },
   "require": {
-    "php": "7.4.*|8.0.*|8.1.*|8.2.*|8.3.*",
+    "php": "8.0.*|8.1.*|8.2.*|8.3.*|8.4.*",
     "illuminate/testing": "^7.0|^8.0|^9.0|^10.0|^11.0",
     "illuminate/session": "^7.0|^8.0|^9.0|^10.0|^11.0",
     "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0"

--- a/src/Laraflash.php
+++ b/src/Laraflash.php
@@ -2,9 +2,10 @@
 
 namespace Gbuckingham89\Laraflash;
 
+use Illuminate\Support\HtmlString;
+
 class Laraflash
 {
-
     /**
      * @var \Gbuckingham89\Laraflash\SessionStorage
      */
@@ -31,12 +32,12 @@ class Laraflash
     }
 
     /**
-     * @param string $message
+     * @param string|HtmlString $message
      * @param string $level
      *
      * @return $this
      */
-    public function flash(string $message, string $level): self
+    public function flash(string|HtmlString $message, string $level): self
     {
         $this->session->flash('laraflash.message', $message);
         $this->session->flash('laraflash.level', $level);
@@ -45,41 +46,41 @@ class Laraflash
     }
 
     /**
-     * @param string $message
+     * @param string|HtmlString $message
      *
      * @return $this
      */
-    public function success(string $message) :self
+    public function success(string|HtmlString $message) :self
     {
         return $this->flash($message, 'success');
     }
 
     /**
-     * @param string $message
+     * @param string|HtmlString $message
      *
      * @return $this
      */
-    public function info(string $message): self
+    public function info(string|HtmlString $message): self
     {
         return $this->flash($message, 'info');
     }
 
     /**
-     * @param string $message
+     * @param string|HtmlString $message
      *
      * @return $this
      */
-    public function warning(string $message): self
+    public function warning(string|HtmlString $message): self
     {
         return $this->flash($message, 'warning');
     }
 
     /**
-     * @param string $message
+     * @param string|HtmlString $message
      *
      * @return $this
      */
-    public function danger(string $message): self
+    public function danger(string|HtmlString $message): self
     {
         return $this->flash($message, 'danger');
     }

--- a/src/LaraflashAssertions.php
+++ b/src/LaraflashAssertions.php
@@ -2,6 +2,7 @@
 
 namespace Gbuckingham89\Laraflash;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\Testing\TestResponse;
 
 abstract class LaraflashAssertions
@@ -18,12 +19,12 @@ abstract class LaraflashAssertions
     /**
      * @param \Illuminate\Testing\TestResponse $response
      * @param string $level
-     * @param string|null $message
+     * @param string|HtmlString|null $message
      */
     public static function assertResponseHasLaraflash(
         TestResponse $response,
         string $level,
-        ?string $message = null
+        string|HtmlString|null $message = null
     ): void {
         $response->assertSessionHas('laraflash.level', $level);
         $response->assertSessionHas('laraflash.message', $message);
@@ -31,36 +32,48 @@ abstract class LaraflashAssertions
 
     /**
      * @param \Illuminate\Testing\TestResponse $response
-     * @param string|null $message
+     * @param string|HtmlString|null $message
      */
-    public static function assertResponseHasLaraflashSuccess(TestResponse $response, ?string $message = null): void
+    public static function assertResponseHasLaraflashSuccess(
+        TestResponse $response,
+        string|HtmlString|null $message = null,
+    ): void
     {
         self::assertResponseHasLaraflash($response, 'success', $message);
     }
 
     /**
      * @param \Illuminate\Testing\TestResponse $response
-     * @param string|null $message
+     * @param string|HtmlString|null $message
      */
-    public static function assertResponseHasLaraflashInfo(TestResponse $response, ?string $message = null): void
+    public static function assertResponseHasLaraflashInfo(
+        TestResponse $response,
+        string|HtmlString|null $message = null,
+    ): void
     {
         self::assertResponseHasLaraflash($response, 'info', $message);
     }
 
     /**
      * @param \Illuminate\Testing\TestResponse $response
-     * @param string|null $message
+     * @param string|HtmlString|null $message
      */
-    public static function assertResponseHasLaraflashWarning(TestResponse $response, ?string $message = null): void
+    public static function assertResponseHasLaraflashWarning(
+        TestResponse $response,
+        string|HtmlString|null $message = null,
+    ): void
     {
         self::assertResponseHasLaraflash($response, 'warning', $message);
     }
 
     /**
      * @param \Illuminate\Testing\TestResponse $response
-     * @param string|null $message
+     * @param string|HtmlString|null $message
      */
-    public static function assertResponseHasLaraflashDanger(TestResponse $response, ?string $message = null): void
+    public static function assertResponseHasLaraflashDanger(
+        TestResponse $response,
+        string|HtmlString|null $message = null,
+    ): void
     {
         self::assertResponseHasLaraflash($response, 'danger', $message);
     }

--- a/src/LaravelSessionStorage.php
+++ b/src/LaravelSessionStorage.php
@@ -6,20 +6,19 @@ use Illuminate\Session\Store;
 
 class LaravelSessionStorage implements SessionStorage
 {
-
     /**
      * @var \Illuminate\Session\Store
      */
-    private Store $session;
+    private Store $sessionStore;
 
     /**
      * LaravelSessionStorage constructor.
      *
-     * @param \Illuminate\Session\Store $session
+     * @param \Illuminate\Session\Store $sessionStore
      */
-    function __construct(Store $session)
+    function __construct(Store $sessionStore)
     {
-        $this->session = $session;
+        $this->sessionStore = $sessionStore;
     }
 
 	/**
@@ -30,9 +29,9 @@ class LaravelSessionStorage implements SessionStorage
      *
      * @return void
 	 */
-	public function flash(string $key, $value=null): void
+	public function flash(string $key, mixed $value = null): void
 	{
-		$this->session->flash($key, $value);
+		$this->sessionStore->flash($key, $value);
 	}
 
 	/**
@@ -43,9 +42,9 @@ class LaravelSessionStorage implements SessionStorage
      *
      * @return void
 	 */
-	public function get(string $key, $default=null): void
+	public function get(string $key, mixed $default = null): void
 	{
-		$this->session->get($key, $default);
+		$this->sessionStore->get($key, $default);
 	}
 
 	/**
@@ -55,7 +54,6 @@ class LaravelSessionStorage implements SessionStorage
 	 */
 	public function reflash(): void
 	{
-		$this->session->reflash();
+		$this->sessionStore->reflash();
 	}
-
 }

--- a/src/SessionStorage.php
+++ b/src/SessionStorage.php
@@ -11,7 +11,7 @@ interface SessionStorage
      *
      * @return void
      */
-    public function flash(string $key, $value=null): void;
+    public function flash(string $key, mixed $value = null): void;
 
     /**
      * @param string $key
@@ -19,7 +19,7 @@ interface SessionStorage
      *
      * @return void
      */
-    public function get(string $key, $default=null): void;
+    public function get(string $key, mixed $default = null): void;
 
     /**
      * @return void

--- a/views/laraflash.blade.php
+++ b/views/laraflash.blade.php
@@ -1,6 +1,6 @@
 @if(Session::has('laraflash.message'))
     <div class="alert alert-{{ Session::get('laraflash.level') }}">
         <button title="Hide" type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        {!! Session::get('laraflash.message') !!}
+        {{ Session::get('laraflash.message') }}
     </div>
 @endif


### PR DESCRIPTION
- Add support for `HtmlString` as messages
- Fix potential XSS issue with default view template
- Drop support for PHP < 8.0 _(no support for union types)_